### PR TITLE
Wr/update generator

### DIFF
--- a/api/v2beta1/atom_conversion.go
+++ b/api/v2beta1/atom_conversion.go
@@ -87,6 +87,7 @@ func (a *Atom) ConvertTo(dstRaw conversion.Hub) error {
 		// Map the links
 		for _, srcLink := range srcDataset.Links {
 			dstLink := pdoknlv3.Link{
+				Rel:   "describedby",
 				Title: &srcLink.Type,
 				Href:  srcLink.URI,
 			}

--- a/internal/controller/atom_controller.go
+++ b/internal/controller/atom_controller.go
@@ -191,11 +191,11 @@ func (r *AtomReconciler) createOrUpdateAllForAtom(ctx context.Context, atom *pdo
 	configMap := getBareConfigMap(atom)
 
 	// mutate (also) before to get the hash suffix in the name
-	if err = r.mutateConfigMap(atom, ownerInfo, configMap); err != nil {
+	if err = r.mutateAtomGeneratorConfigMap(atom, ownerInfo, configMap); err != nil {
 		return operationResults, err
 	}
 	operationResults[smoothoperatorutils.GetObjectFullName(r.Client, atom)], err = controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
-		return r.mutateConfigMap(atom, ownerInfo, configMap)
+		return r.mutateAtomGeneratorConfigMap(atom, ownerInfo, configMap)
 	})
 	if err != nil {
 		return operationResults, fmt.Errorf("unable to create/update resource %s: %w", smoothoperatorutils.GetObjectFullName(c, configMap), err)
@@ -280,7 +280,7 @@ func (r *AtomReconciler) createOrUpdateAllForAtom(ctx context.Context, atom *pdo
 func (r *AtomReconciler) deleteAllForAtom(ctx context.Context, atom *pdoknlv3.Atom, ownerInfo *smoothoperatorv1.OwnerInfo) (err error) {
 	configMap := getBareConfigMap(atom)
 	// mutate (also) before to get the hash suffix in the name
-	if err = r.mutateConfigMap(atom, ownerInfo, configMap); err != nil {
+	if err = r.mutateAtomGeneratorConfigMap(atom, ownerInfo, configMap); err != nil {
 		return
 	}
 	objects := []client.Object{
@@ -308,7 +308,7 @@ func getBareConfigMap(obj metav1.Object) *corev1.ConfigMap {
 	}
 }
 
-func (r *AtomReconciler) mutateConfigMap(atom *pdoknlv3.Atom, ownerInfo *smoothoperatorv1.OwnerInfo, configMap *corev1.ConfigMap) error {
+func (r *AtomReconciler) mutateAtomGeneratorConfigMap(atom *pdoknlv3.Atom, ownerInfo *smoothoperatorv1.OwnerInfo, configMap *corev1.ConfigMap) error {
 	labels := smoothoperatorutils.CloneOrEmptyMap(atom.GetLabels())
 	labels[appLabelKey] = atomName
 	if err := smoothoperatorutils.SetImmutableLabels(r.Client, configMap, labels); err != nil {

--- a/internal/controller/atom_controller_test.go
+++ b/internal/controller/atom_controller_test.go
@@ -805,13 +805,15 @@ func Test_getGeneratorConfig(t *testing.T) {
 					Spec: pdoknlv3.AtomSpec{
 						Lifecycle: &smoothoperatormodel.Lifecycle{},
 						Service: pdoknlv3.Service{
+							Stylesheet: smoothoperatorutils.Pointer("/atom/style/style.xsl"),
+							Lang:       "nl",
 							ServiceMetadataLinks: &pdoknlv3.MetadataLink{
 								MetadataIdentifier: "7c5bbc80-d6f1-48d7-ba75-xxxxxxxxxxxx",
 								Templates:          []string{"csw", "opensearch", "html"},
 							},
 							DatasetFeeds: []pdoknlv3.DatasetFeed{
 								{
-									TechnicalName: "https://service.pdok.nl/test/atom/index.xml",
+									TechnicalName: "brocpt",
 									Title:         "BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM",
 									Subtitle:      "BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM",
 									//Links:         []pdoknlv3.Link{},
@@ -827,7 +829,7 @@ func Test_getGeneratorConfig(t *testing.T) {
 									SpatialDatasetIdentifierNamespace: smoothoperatorutils.Pointer("http://www.pdok.nl"),
 									Entries: []pdoknlv3.Entry{
 										{
-											TechnicalName: "https://service.pdok.nl/test/atom/bro_geotechnisch_sondeeronderzoek_cpt_inspire_geharmoniseerd_geologie.xml",
+											TechnicalName: "bro_geotechnisch_sondeeronderzoek_cpt_inspire_geharmoniseerd_geologie",
 											Title:         smoothoperatorutils.Pointer("BRO - Geotechnisch sondeeronderzoek (CPT) INSPIRE geharmoniseerd - Geologie"),
 											Content:       smoothoperatorutils.Pointer("Gegevens van geotechnisch sondeeronderzoek (kenset) zoals opgeslagen in de Basis Registratie Ondergrond (BRO)."),
 											DownloadLinks: []pdoknlv3.DownloadLink{

--- a/internal/controller/generator/mapper.go
+++ b/internal/controller/generator/mapper.go
@@ -14,9 +14,6 @@ import (
 )
 
 func MapAtomV3ToAtomGeneratorConfig(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo) (atomGeneratorConfig atomfeed.Feeds, err error) {
-
-	var describedbyLink, searchLink, relatedLink atomfeed.Link
-
 	if ownerInfo.Spec.Atom == nil {
 		return atomGeneratorConfig, errors.New("ownerInfo has no Atom information defined")
 	}
@@ -48,12 +45,7 @@ func MapAtomV3ToAtomGeneratorConfig(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo) 
 		Title:         escapeQuotes(atom.Spec.Service.Title),
 		Subtitle:      escapeQuotes(atom.Spec.Service.Subtitle),
 		// Index Feed Links
-		Link: []atomfeed.Link{
-			selfLink,
-			describedbyLink,
-			searchLink,
-			relatedLink,
-		},
+		Link:   links,
 		Rights: atom.Spec.Service.Rights,
 		Author: getAuthor(ownerInfo.Spec.Atom.Author),
 		Entry:  entries,

--- a/internal/controller/generator/mapper.go
+++ b/internal/controller/generator/mapper.go
@@ -11,7 +11,6 @@ import (
 	pdoknlv3 "github.com/pdok/atom-operator/api/v3"
 	v1 "github.com/pdok/smooth-operator/api/v1"
 	smoothoperatormodel "github.com/pdok/smooth-operator/model"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func MapAtomV3ToAtomGeneratorConfig(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo) (atomGeneratorConfig atomfeed.Feeds, err error) {
@@ -22,60 +21,59 @@ func MapAtomV3ToAtomGeneratorConfig(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo) 
 		return atomGeneratorConfig, errors.New("ownerInfo has no Atom information defined")
 	}
 
-	language := "nl"
-	xmlSheet := pdoknlv3.GetBaseURL() + "/atom/style/style.xsl"
-	selfLink := getSelfLink(atom, language)
-	describedbyLink, err = getCSWDescribedbyLink(atom, language, ownerInfo)
-	if err != nil {
-		return atomfeed.Feeds{}, err
-	}
-	searchLink, err = getSearchLink(atom, language, ownerInfo)
-	if err != nil {
-		return atomfeed.Feeds{}, err
-	}
-	relatedLink, err = getHTMLRelatedLink(atom, language, ownerInfo)
-	if err != nil {
-		return atomfeed.Feeds{}, err
-	}
-	latestUpdated, err := getLatestUpdate(atom.Spec.Service.DatasetFeeds)
-	if err != nil {
-		return atomfeed.Feeds{}, err
+	selfLink := getSelfLink(atom)
+	links := []atomfeed.Link{selfLink}
+	if atom.Spec.Service.ServiceMetadataLinks != nil {
+		err = addMetadataLinks(*atom.Spec.Service.ServiceMetadataLinks, ownerInfo, &links, "NGR pagina voor deze download service", false)
+		if err != nil {
+			return atomfeed.Feeds{}, err
+		}
 	}
 
+	// TODO append custom links to links (requires mapping)
+	// links = append(links, atom.Spec.Service.Links...)
+
 	atomGeneratorConfig.Feeds = []atomfeed.Feed{}
+	entries, err := getServiceEntries(atom, ownerInfo)
+	if err != nil {
+		return atomfeed.Feeds{}, err
+	}
 	serviceFeed := atomfeed.Feed{
-		XMLStylesheet: &xmlSheet,
+		XMLStylesheet: atom.Spec.Service.Stylesheet,
 		Xmlns:         "http://www.w3.org/2005/Atom",
 		Georss:        "http://www.georss.org/georss",
 		InspireDls:    "http://inspire.ec.europa.eu/schemas/inspire_dls/1.0",
-		Lang:          &language,
+		Lang:          &atom.Spec.Service.Lang,
 		ID:            atom.Spec.Service.BaseURL + "/index.xml",
 		Title:         escapeQuotes(atom.Spec.Service.Title),
 		Subtitle:      escapeQuotes(atom.Spec.Service.Subtitle),
-		// Feed Links
+		// Index Feed Links
 		Link: []atomfeed.Link{
 			selfLink,
 			describedbyLink,
 			searchLink,
 			relatedLink,
 		},
-		Rights:  atom.Spec.Service.Rights,
-		Updated: &latestUpdated,
-		Author:  getServiceAuthor(ownerInfo.Spec.Atom.Author),
-		Entry:   getServiceEntries(atom, language, ownerInfo, &latestUpdated),
+		Rights: atom.Spec.Service.Rights,
+		Author: getAuthor(ownerInfo.Spec.Atom.Author),
+		Entry:  entries,
 	}
 	atomGeneratorConfig.Feeds = append(atomGeneratorConfig.Feeds, serviceFeed)
 
 	for _, datasetFeed := range atom.Spec.Service.DatasetFeeds {
+		links, err := getDatasetLinks(atom, ownerInfo, datasetFeed)
+		if err != nil {
+			return atomfeed.Feeds{}, err
+		}
 		dsFeed := atomfeed.Feed{
 			ID:            atom.Spec.Service.BaseURL + "/" + datasetFeed.TechnicalName + ".xml",
 			Title:         escapeQuotes(datasetFeed.Title),
 			Subtitle:      escapeQuotes(datasetFeed.Subtitle),
-			Lang:          &language,
-			Link:          getDatasetLinks(atom, ownerInfo, datasetFeed),
+			Lang:          &atom.Spec.Service.Lang,
+			Link:          links,
 			Rights:        atom.Spec.Service.Rights,
-			XMLStylesheet: &xmlSheet,
-			Author:        getDatasetAuthor(datasetFeed.Author),
+			XMLStylesheet: atom.Spec.Service.Stylesheet,
+			Author:        getAuthor(datasetFeed.Author),
 			Entry:         getDatasetEntries(atom, datasetFeed),
 		}
 		atomGeneratorConfig.Feeds = append(atomGeneratorConfig.Feeds, dsFeed)
@@ -83,38 +81,35 @@ func MapAtomV3ToAtomGeneratorConfig(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo) 
 	return atomGeneratorConfig, err
 }
 
-func getLatestUpdate(feeds []pdoknlv3.DatasetFeed) (string, error) {
-	if len(feeds) == 0 {
-		return "", errors.New("this atom doesn't have any dataset feeds")
-	}
-
-	var updateTime *metav1.Time
-	for _, datasetFeed := range feeds {
-		for _, entry := range datasetFeed.Entries {
-			if updateTime == nil || updateTime.Before(&entry.Updated) {
-				updateTime = &entry.Updated
-			}
-		}
-	}
-	if updateTime == nil {
-		return "", nil
-	}
-	return updateTime.Format(time.RFC3339), nil
-}
-
-func getServiceEntries(atom pdoknlv3.Atom, language string, ownerInfo v1.OwnerInfo, latestUpdated *string) []atomfeed.Entry {
+func getServiceEntries(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo) ([]atomfeed.Entry, error) {
 	var retEntriesArray []atomfeed.Entry
 	for _, datasetFeed := range atom.Spec.Service.DatasetFeeds {
+		id := atom.Spec.Service.BaseURL + "/" + datasetFeed.TechnicalName + ".xml"
+		var links []atomfeed.Link
+		if datasetFeed.DatasetMetadataLinks != nil {
+			err := addMetadataLinks(*datasetFeed.DatasetMetadataLinks, ownerInfo, &links, "", true)
+			if err != nil {
+				return nil, err
+			}
+		}
+		alternateLink := atomfeed.Link{
+			Rel:   "alternate",
+			Href:  id,
+			Type:  "application/atom+xml",
+			Title: escapeQuotes(datasetFeed.Title),
+		}
+		links = append(links, alternateLink)
 		datasetEntry := atomfeed.Entry{
-			ID:                                atom.Spec.Service.BaseURL + "/" + datasetFeed.TechnicalName + ".xml",
+			ID:                                id,
 			Title:                             escapeQuotes(datasetFeed.Title),
 			SpatialDatasetIdentifierCode:      datasetFeed.SpatialDatasetIdentifierCode,
 			SpatialDatasetIdentifierNamespace: datasetFeed.SpatialDatasetIdentifierNamespace,
-			Link:                              getServiceEntryLinks(atom, language, ownerInfo, datasetFeed),
-			Updated:                           latestUpdated,
+			Link:                              links,
 			Summary:                           escapeQuotes(datasetFeed.Subtitle),
 			Category:                          []atomfeed.Category{},
 		}
+
+		// TODO willen we hier een verbetering doorvoeren dat het altijd de max polygon van alle entries maakt?
 		// Take the polygon bbox of the first entry, assuming all are equal
 		if len(datasetFeed.Entries) > 0 {
 			datasetEntry.Polygon = datasetFeed.Entries[0].Polygon.BBox.ToPolygon()
@@ -132,29 +127,7 @@ func getServiceEntries(atom pdoknlv3.Atom, language string, ownerInfo v1.OwnerIn
 		retEntriesArray = append(retEntriesArray, datasetEntry)
 	}
 
-	return retEntriesArray
-}
-
-func getServiceEntryLinks(atom pdoknlv3.Atom, language string, ownerInfo v1.OwnerInfo, datasetFeed pdoknlv3.DatasetFeed) []atomfeed.Link {
-	describedByLinkHref, _ := replaceMustachTemplate(ownerInfo.Spec.MetadataUrls.CSW.HrefTemplate, atom.Spec.Service.ServiceMetadataLinks.MetadataIdentifier)
-	describedByLink := atomfeed.Link{
-		Rel:      "describedby",
-		Href:     describedByLinkHref,
-		Type:     "application/xml",
-		Hreflang: &language,
-	}
-
-	alternateLink := atomfeed.Link{
-		Rel:   "alternate",
-		Href:  atom.Spec.Service.BaseURL + "/" + datasetFeed.TechnicalName + ".xml",
-		Type:  "application/atom+xml",
-		Title: datasetFeed.Title,
-	}
-	return []atomfeed.Link{
-		describedByLink,
-		alternateLink,
-	}
-
+	return retEntriesArray, nil
 }
 
 func getCategory(srs pdoknlv3.SRS) atomfeed.Category {
@@ -164,94 +137,76 @@ func getCategory(srs pdoknlv3.SRS) atomfeed.Category {
 	}
 }
 
-func getServiceAuthor(author smoothoperatormodel.Author) atomfeed.Author {
+func getAuthor(author smoothoperatormodel.Author) atomfeed.Author {
 	return atomfeed.Author{
 		Name:  author.Name,
 		Email: author.Email,
 	}
 }
 
-func getDatasetAuthor(author smoothoperatormodel.Author) atomfeed.Author {
-	return atomfeed.Author{
-		Name:  author.Name,
-		Email: author.Email,
-	}
-}
-
-func getSelfLink(atom pdoknlv3.Atom, language string) atomfeed.Link {
+func getSelfLink(atom pdoknlv3.Atom) atomfeed.Link {
 	return atomfeed.Link{
-		Rel:      "self",
-		Href:     atom.Spec.Service.BaseURL + "/index.xml",
-		Title:    escapeQuotes(atom.Spec.Service.Title),
-		Type:     "application/atom+xml",
-		Hreflang: &language,
+		Rel:   "self",
+		Href:  atom.Spec.Service.BaseURL + "/index.xml",
+		Title: escapeQuotes(atom.Spec.Service.Title),
+		Type:  "application/atom+xml",
 	}
 }
 
-func replaceMustachTemplate(hrefTemplate string, identifier string) (string, error) {
+func replaceMustacheTemplate(hrefTemplate string, identifier string) (string, error) {
 	templateVariable := map[string]string{"identifier": identifier}
 	return mustache.Render(hrefTemplate, templateVariable)
 }
 
-func getCSWDescribedbyLink(atom pdoknlv3.Atom, language string, ownerInfo v1.OwnerInfo) (atomfeed.Link, error) {
-	if atom.Spec.Service.ServiceMetadataLinks != nil {
-		for _, template := range atom.Spec.Service.ServiceMetadataLinks.Templates {
-			if template == "csw" {
-				href, err := replaceMustachTemplate(ownerInfo.Spec.MetadataUrls.CSW.HrefTemplate, atom.Spec.Service.ServiceMetadataLinks.MetadataIdentifier)
-				if err != nil {
-					return atomfeed.Link{}, err
-				}
-				return atomfeed.Link{
-					Rel:      "describedby",
-					Href:     href,
-					Type:     "application/xml",
-					Hreflang: &language,
-				}, nil
+func addMetadataLinks(metadataLinks pdoknlv3.MetadataLink, ownerInfo v1.OwnerInfo, links *[]atomfeed.Link, htmlTitle string, onlyCSW bool) error {
+	for _, template := range metadataLinks.Templates {
+		if template == "csw" {
+			href, err := replaceMustacheTemplate(ownerInfo.Spec.MetadataUrls.CSW.HrefTemplate, metadataLinks.MetadataIdentifier)
+			if err != nil {
+				return err
+			}
+			link := atomfeed.Link{
+				Rel:  "describedby",
+				Href: href,
+				Type: "application/xml",
+			}
+			*links = append(*links, link)
+			if onlyCSW {
+				return nil
 			}
 		}
-	}
-
-	return atomfeed.Link{}, errors.New("ownerInfo doesn't have a CSW template")
-}
-
-func getSearchLink(atom pdoknlv3.Atom, language string, ownerInfo v1.OwnerInfo) (atomfeed.Link, error) {
-	for _, template := range atom.Spec.Service.ServiceMetadataLinks.Templates {
 		if template == "opensearch" {
-			href, err := replaceMustachTemplate(ownerInfo.Spec.MetadataUrls.OpenSearch.HrefTemplate, atom.Spec.Service.ServiceMetadataLinks.MetadataIdentifier)
+			href, err := replaceMustacheTemplate(ownerInfo.Spec.MetadataUrls.OpenSearch.HrefTemplate, metadataLinks.MetadataIdentifier)
 			if err != nil {
-				return atomfeed.Link{}, err
+				return err
 			}
-
-			return atomfeed.Link{
-				Rel:      "search",
-				Href:     href,
-				Type:     "application/xml",
-				Hreflang: &language,
-			}, nil
+			link := atomfeed.Link{
+				Rel:   "search",
+				Href:  href,
+				Title: "Open Search document voor INSPIRE Download service PDOK", // TODO move to ownerRef?
+				Type:  "application/opensearchdescription+xml",
+			}
+			*links = append(*links, link)
 		}
-	}
-	return atomfeed.Link{}, errors.New("ownerInfo doesn't have an opensearch template")
-}
-
-func getHTMLRelatedLink(atom pdoknlv3.Atom, language string, ownerInfo v1.OwnerInfo) (atomfeed.Link, error) {
-	for _, template := range atom.Spec.Service.ServiceMetadataLinks.Templates {
 		if template == "html" {
-			href, err := replaceMustachTemplate(ownerInfo.Spec.MetadataUrls.HTML.HrefTemplate, atom.Spec.Service.ServiceMetadataLinks.MetadataIdentifier)
+			href, err := replaceMustacheTemplate(ownerInfo.Spec.MetadataUrls.HTML.HrefTemplate, metadataLinks.MetadataIdentifier)
 			if err != nil {
-				return atomfeed.Link{}, err
+				return err
 			}
-			return atomfeed.Link{
-				Rel:      "related",
-				Href:     href,
-				Type:     "text/html",
-				Hreflang: &language,
-			}, nil
+			link := atomfeed.Link{
+				Rel:   "related",
+				Href:  href,
+				Type:  "text/html",
+				Title: htmlTitle,
+			}
+			*links = append(*links, link)
 		}
 	}
-	return atomfeed.Link{}, errors.New("ownerInfo doesn't have a html template")
+
+	return nil
 }
 
-func getDatasetLinks(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo, datasetFeed pdoknlv3.DatasetFeed) []atomfeed.Link {
+func getDatasetLinks(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo, datasetFeed pdoknlv3.DatasetFeed) ([]atomfeed.Link, error) {
 
 	selfLink := atomfeed.Link{
 		Rel:  "self",
@@ -263,29 +218,22 @@ func getDatasetLinks(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo, datasetFeed pdo
 		Type:  "application/atom+xml",
 		Title: "Top Atom Download Service Feed",
 	}
-	describedByLinkHref, _ := replaceMustachTemplate(ownerInfo.Spec.MetadataUrls.CSW.HrefTemplate, atom.Spec.Service.ServiceMetadataLinks.MetadataIdentifier)
-	describedbyLink := atomfeed.Link{
-		Rel:  "describedby",
-		Href: describedByLinkHref,
-		Type: "text.html",
-	}
-	relatedLinkHref, _ := replaceMustachTemplate(ownerInfo.Spec.MetadataUrls.HTML.HrefTemplate, atom.Spec.Service.ServiceMetadataLinks.MetadataIdentifier)
-	relatedLink := atomfeed.Link{
-		Href:  relatedLinkHref,
-		Type:  "text.html",
-		Title: "NGR pagina voor deze dataset",
-	}
 
 	links := []atomfeed.Link{
 		selfLink,
 		upLink,
-		describedbyLink,
-		relatedLink,
+	}
+
+	if datasetFeed.DatasetMetadataLinks != nil {
+		err := addMetadataLinks(*datasetFeed.DatasetMetadataLinks, ownerInfo, &links, "NGR pagina voor deze dataset", false)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	for _, link := range datasetFeed.Links {
 		linkDescribedbyLink := atomfeed.Link{
-			Rel:      "describedby",
+			Rel:      link.Rel,
 			Href:     link.Href,
 			Type:     link.Type,
 			Hreflang: link.Hreflang,
@@ -296,7 +244,7 @@ func getDatasetLinks(atom pdoknlv3.Atom, ownerInfo v1.OwnerInfo, datasetFeed pdo
 		links = append(links, linkDescribedbyLink)
 	}
 
-	return links
+	return links, nil
 }
 
 func getDatasetEntries(atom pdoknlv3.Atom, datasetFeed pdoknlv3.DatasetFeed) []atomfeed.Entry {
@@ -309,11 +257,12 @@ func getDatasetEntries(atom pdoknlv3.Atom, datasetFeed pdoknlv3.DatasetFeed) []a
 			Rights:   atom.Spec.Service.Rights,
 			Category: []atomfeed.Category{getCategory(entry.SRS)},
 			Polygon:  entry.Polygon.BBox.ToPolygon(),
-			Summary:  escapeQuotes(datasetFeed.Subtitle),
 		}
 
 		if entry.Title != nil {
 			datasetEntry.Title = escapeQuotes(*entry.Title)
+		} else {
+			datasetEntry.Title = escapeQuotes(datasetFeed.Title)
 		}
 
 		if entry.Content != nil {
@@ -350,6 +299,8 @@ func getDatasetEntries(atom pdoknlv3.Atom, datasetFeed pdoknlv3.DatasetFeed) []a
 
 func getEmptyRelCount(entry pdoknlv3.Entry) (count int) {
 	for _, downloadLink := range entry.DownloadLinks {
+		// TODO zou een "" niet eigenlijk een error moeten zijn?
+		// maar dat hoort mogelijk meer bij de admission
 		if downloadLink.Rel == nil || *downloadLink.Rel == "" {
 			count++
 		}
@@ -369,10 +320,8 @@ func getDownloadLinkRel(downloadLink pdoknlv3.DownloadLink, emptyRelCount int) (
 	return
 }
 
-func getDownloadLinkHref(downloadLink pdoknlv3.DownloadLink, atom pdoknlv3.Atom) (href string) {
-	href = atom.Spec.Service.BaseURL + "/downloads"
-	href += "/" + downloadLink.GetBlobName()
-	return
+func getDownloadLinkHref(downloadLink pdoknlv3.DownloadLink, atom pdoknlv3.Atom) string {
+	return atom.Spec.Service.BaseURL + "/downloads" + "/" + downloadLink.GetBlobName()
 }
 
 // Using internal url, atom generator uses this url to determine content-length and
@@ -386,10 +335,9 @@ func getDownloadLinkTitle(datasetFeed pdoknlv3.DatasetFeed, entry pdoknlv3.Entry
 	if entry.Title != nil && *entry.Title != "" {
 		title = *entry.Title
 	} else {
-		title = datasetFeed.Title
+		title = escapeQuotes(datasetFeed.Title)
 	}
-	title += "-"
-	title += downloadLink.GetBlobName()
+	title += "-" + downloadLink.GetBlobName()
 	return
 }
 

--- a/internal/controller/test_data/generator_config/scenario-2.yaml
+++ b/internal/controller/test_data/generator_config/scenario-2.yaml
@@ -15,43 +15,38 @@ feeds:
         data: null
         rel: self
         type: application/atom+xml
-        hreflang: nl
       - href: https://www.ngr.nl/geonetwork/srv/dut/csw?service=CSW&version=2.0.2&request=GetRecordById&outputschema=http://www.isotc211.org/2005/gmd&elementsetname=full&id=7c5bbc80-d6f1-48d7-ba75-xxxxxxxxxxxx
         data: null
         rel: describedby
         type: application/xml
-        hreflang: nl
       - href: https://www.ngr.nl/geonetwork/opensearch/dut/7c5bbc80-d6f1-48d7-ba75-xxxxxxxxxxxx/OpenSearchDescription.xml
         data: null
         rel: search
-        type: application/xml
-        hreflang: nl
+        type: application/opensearchdescription+xml
+        title: Open Search document voor INSPIRE Download service PDOK
       - href: https://www.ngr.nl/geonetwork/srv/dut/catalog.search#/metadata/7c5bbc80-d6f1-48d7-ba75-xxxxxxxxxxxx
         data: null
         rel: related
         type: text/html
-        hreflang: nl
+        title: NGR pagina voor deze download service
     rights: ""
-    updated: "2025-03-05T05:05:05Z"
     author:
-      name: "owner"
-      email: "info@test.com"
+      name: owner
+      email: info@test.com
     entry:
-      - id: /https://service.pdok.nl/test/atom/index.xml.xml
+      - id: /brocpt.xml
         title: BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM
         summary: BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM
         link:
-          - href: https://www.ngr.nl/geonetwork/srv/dut/csw?service=CSW&version=2.0.2&request=GetRecordById&outputschema=http://www.isotc211.org/2005/gmd&elementsetname=full&id=7c5bbc80-d6f1-48d7-ba75-xxxxxxxxxxxx
+          - href: https://www.ngr.nl/geonetwork/srv/dut/csw?service=CSW&version=2.0.2&request=GetRecordById&outputschema=http://www.isotc211.org/2005/gmd&elementsetname=full&id=d893c05b-907e-47f2-9cbd-ceb08e68732c
             data: null
             rel: describedby
             type: application/xml
-            hreflang: nl
-          - href: /https://service.pdok.nl/test/atom/index.xml.xml
+          - href: /brocpt.xml
             data: null
             rel: alternate
             type: application/atom+xml
             title: BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM
-        updated: "2025-03-05T05:05:05Z"
         polygon: 1 1 1 2 2 2 2 1 1 1
         category:
           - term: https://www.opengis.net/def/crs/EPSG/0/28992
@@ -64,11 +59,11 @@ feeds:
     stylesheet: /atom/style/style.xsl
     xmlns: ""
     lang: nl
-    id: /https://service.pdok.nl/test/atom/index.xml.xml
+    id: /brocpt.xml
     title: BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM
     subtitle: BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM
     link:
-      - href: /https://service.pdok.nl/test/atom/index.xml.xml
+      - href: /brocpt.xml
         data: null
         rel: self
       - href: /index.xml
@@ -76,23 +71,23 @@ feeds:
         rel: up
         type: application/atom+xml
         title: Top Atom Download Service Feed
-      - href: https://www.ngr.nl/geonetwork/srv/dut/csw?service=CSW&version=2.0.2&request=GetRecordById&outputschema=http://www.isotc211.org/2005/gmd&elementsetname=full&id=7c5bbc80-d6f1-48d7-ba75-xxxxxxxxxxxx
+      - href: https://www.ngr.nl/geonetwork/srv/dut/csw?service=CSW&version=2.0.2&request=GetRecordById&outputschema=http://www.isotc211.org/2005/gmd&elementsetname=full&id=d893c05b-907e-47f2-9cbd-ceb08e68732c
         data: null
         rel: describedby
-        type: text.html
-      - href: https://www.ngr.nl/geonetwork/srv/dut/catalog.search#/metadata/7c5bbc80-d6f1-48d7-ba75-xxxxxxxxxxxx
+        type: application/xml
+      - href: https://www.ngr.nl/geonetwork/srv/dut/catalog.search#/metadata/d893c05b-907e-47f2-9cbd-ceb08e68732c
         data: null
-        type: text.html
+        rel: related
+        type: text/html
         title: NGR pagina voor deze dataset
     rights: ""
     author:
       name: owner
       email: info@test.com
     entry:
-      - id: /https://service.pdok.nl/test/atom/bro_geotechnisch_sondeeronderzoek_cpt_inspire_geharmoniseerd_geologie.xml.xml
+      - id: /bro_geotechnisch_sondeeronderzoek_cpt_inspire_geharmoniseerd_geologie.xml
         title: BRO - Geotechnisch sondeeronderzoek (CPT) INSPIRE geharmoniseerd - Geologie
         content: Gegevens van geotechnisch sondeeronderzoek (kenset) zoals opgeslagen in de Basis Registratie Ondergrond (BRO).
-        summary: BRO - Geotechnisch sondeeronderzoek (CPT) - Geologie (INSPIRE geharmoniseerd) ATOM
         link:
           - href: /downloads/dataset-1-file
             data: /http://localazurite.blob.azurite/bucket/key1/dataset-1-file


### PR DESCRIPTION
# Description

improve/fix atom-generator mapper

changes:
- converter zet nu "describedby" voor de custom dataset links (wat hardcoded is in de oude operator)
- mutateConfigMap hernoemt naar mutateAtomGeneratorConfigMap voor duidelijkheid
- 1 functie voor alle metadatalinks handelingen
- lang en stylesheet worden nu overgenomen uit de atom CR
- updated verwijderd behalve bij entries (de atom-generator heeft hier al functionaliteit voor omdit omhoog te propageren)
- de 2 getAuthor in 1 veranderd  (waren precies hetzelfde)
- dataset metadatalinks de dataset metadata laten gebruiken ipv de service metadata
- hrefLang verwijderd uit links die dat niet nodig hebben
- entry title gedefault naar dataset title als nodig
- metadatalink types goed gezet

## Type of change

(Remove irrelevant options)

- Minor change (typo, formatting, version bump)
- New feature
- Improvement of existing feature
- Bugfix
- Refactoring
- Configuration change
- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR