### PR TITLE
Pdok 18407 atom rewrite fix

### DIFF
--- a/internal/controller/middleware.go
+++ b/internal/controller/middleware.go
@@ -34,6 +34,10 @@ func (r *AtomReconciler) mutateStripPrefixMiddleware(atom *pdoknlv3.Atom, middle
 			Prefixes: []string{atom.Spec.Service.BaseURL.Path + "/"}},
 	}
 
+	for _, ingressRouteUrl := range atom.Spec.IngressRouteURLs {
+		middleware.Spec.StripPrefix.Prefixes = append(middleware.Spec.StripPrefix.Prefixes, ingressRouteUrl.URL.Path+"/")
+	}
+
 	if err := smoothutil.EnsureSetGVK(r.Client, middleware, middleware); err != nil {
 		return err
 	}
@@ -101,7 +105,7 @@ func (r *AtomReconciler) mutateDownloadLinkMiddleware(atom *pdoknlv3.Atom, prefi
 	middleware.Spec = traefikiov1alpha1.MiddlewareSpec{
 		ReplacePathRegex: &dynamic.ReplacePathRegex{
 			Regex:       getDownloadLinkRegex(ingressRouteURLs, files),
-			Replacement: "/" + prefix + "/$1",
+			Replacement: "/" + prefix + "/$2",
 		},
 	}
 
@@ -112,17 +116,12 @@ func (r *AtomReconciler) mutateDownloadLinkMiddleware(atom *pdoknlv3.Atom, prefi
 }
 
 func getDownloadLinkRegex(ingressRouteURLs smoothoperatormodel.IngressRouteURLs, files []string) string {
-	if len(ingressRouteURLs) == 1 {
-		return "^" + ingressRouteURLs[0].URL.JoinPath("downloads", "("+strings.Join(files, "|")+")").Path
-	}
-
 	paths := []string{}
 	for _, ingressRouteURL := range ingressRouteURLs {
 		paths = append(paths, ingressRouteURL.URL.Path)
 	}
 
 	return "^(" + strings.Join(paths, "|") + ")/downloads/" + "(" + strings.Join(files, "|") + ")"
-
 }
 
 func getDownloadLinkGroups(links []pdoknlv3.DownloadLink) map[string]struct {

--- a/internal/controller/middleware.go
+++ b/internal/controller/middleware.go
@@ -34,8 +34,8 @@ func (r *AtomReconciler) mutateStripPrefixMiddleware(atom *pdoknlv3.Atom, middle
 			Prefixes: []string{atom.Spec.Service.BaseURL.Path + "/"}},
 	}
 
-	for _, ingressRouteUrl := range atom.Spec.IngressRouteURLs {
-		middleware.Spec.StripPrefix.Prefixes = append(middleware.Spec.StripPrefix.Prefixes, ingressRouteUrl.URL.Path+"/")
+	for _, ingressRouteURL := range atom.Spec.IngressRouteURLs {
+		middleware.Spec.StripPrefix.Prefixes = append(middleware.Spec.StripPrefix.Prefixes, ingressRouteURL.URL.Path+"/")
 	}
 
 	if err := smoothutil.EnsureSetGVK(r.Client, middleware, middleware); err != nil {

--- a/internal/controller/test_data/maximum-atom/expected-output/middleware-downloads-0.yaml
+++ b/internal/controller/test_data/maximum-atom/expected-output/middleware-downloads-0.yaml
@@ -16,4 +16,4 @@ metadata:
 spec:
   replacePathRegex:
     regex: ^(/path|/path/other)/downloads/(index.json|file-1.ext)
-    replacement: /container/prefix-1/$1
+    replacement: /container/prefix-1/$2

--- a/internal/controller/test_data/maximum-atom/expected-output/middleware-downloads-1.yaml
+++ b/internal/controller/test_data/maximum-atom/expected-output/middleware-downloads-1.yaml
@@ -16,4 +16,4 @@ metadata:
 spec:
   replacePathRegex:
     regex: ^(/path|/path/other)/downloads/(file-2.ext)
-    replacement: /container/prefix-2/$1
+    replacement: /container/prefix-2/$2

--- a/internal/controller/test_data/maximum-atom/expected-output/middleware-downloads-2.yaml
+++ b/internal/controller/test_data/maximum-atom/expected-output/middleware-downloads-2.yaml
@@ -16,4 +16,4 @@ metadata:
 spec:
   replacePathRegex:
     regex: ^(/path|/path/other)/downloads/(file-3.ext|file-4.ext)
-    replacement: /container/prefix-3/$1
+    replacement: /container/prefix-3/$2

--- a/internal/controller/test_data/maximum-atom/expected-output/middleware-prefixstrip.yaml
+++ b/internal/controller/test_data/maximum-atom/expected-output/middleware-prefixstrip.yaml
@@ -17,3 +17,5 @@ spec:
   stripPrefix:
     prefixes:
       - /path/
+      - /path/
+      - /path/other/

--- a/internal/controller/test_data/minimal-atom/expected-output/middleware-downloads-0.yaml
+++ b/internal/controller/test_data/minimal-atom/expected-output/middleware-downloads-0.yaml
@@ -15,5 +15,5 @@ metadata:
       controller: true
 spec:
   replacePathRegex:
-    regex: ^/path/downloads/(file.ext)
-    replacement: /container/prefix/$1
+    regex: ^(/path)/downloads/(file.ext)
+    replacement: /container/prefix/$2


### PR DESCRIPTION
# Description

Fixed issue where alternate ingressroute urls are not correctly routed, making only the baseURL ingress functional. The changes in this fix will change the generated ingressroutes such that adding alternative urls will not break the ingresses.

## Type of change

- Bugfix


# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR