### PR TITLE
Changed ingressroute name

### DIFF
--- a/internal/controller/ingressroute.go
+++ b/internal/controller/ingressroute.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 
 	smoothoperatormodel "github.com/pdok/smooth-operator/model"
 	uptimeutils "github.com/pdok/smooth-operator/pkg/uptime-utils"
@@ -34,10 +35,15 @@ func (r *AtomReconciler) mutateIngressRoute(atom *pdoknlv3.Atom, ingressRoute *t
 
 	baseURL := atom.Spec.Service.BaseURL
 
+	title := atom.Spec.Service.Title
+	if !strings.HasSuffix(title, "ATOM") {
+		title += " ATOM"
+	}
+
 	ingressRoute.Annotations = uptimeutils.GetUptimeAnnotations(
 		atom.Annotations,
 		atom.Name+nameSuffix,
-		atom.Spec.Service.Title+" ATOM",
+		title,
 		baseURL.JoinPath("index.xml").String(),
 		atom.Labels,
 	)


### PR DESCRIPTION
# Description

Prevented double "ATOM" reference in ingressroute name

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR